### PR TITLE
Fix HTTP/APT proxy config for debootstrap

### DIFF
--- a/rpi2-gen-image.sh
+++ b/rpi2-gen-image.sh
@@ -182,9 +182,9 @@ fi
 
 # Base debootstrap (unpack only)
 if [ "$ENABLE_MINBASE" = true ] ; then
-  debootstrap --arch=armhf --variant=minbase --foreign --include=${APT_INCLUDES} $RELEASE $R ${APT_PROXY}${APT_SERVER}/debian
+  http_proxy=${APT_PROXY} debootstrap --arch=armhf --variant=minbase --foreign --include=${APT_INCLUDES} $RELEASE $R ${APT_SERVER}/debian
 else
-  debootstrap --arch=armhf --foreign --include=${APT_INCLUDES} $RELEASE $R ${APT_PROXY}${APT_SERVER}/debian
+  http_proxy=${APT_PROXY} debootstrap --arch=armhf --foreign --include=${APT_INCLUDES} $RELEASE $R ${APT_SERVER}/debian
 fi
 
 # Copy qemu emulator binary to chroot


### PR DESCRIPTION
On my machine, the proxy variable in the debootstrap command caused an error. This sets the `http_proxy` environment variable to the value of APT_PROXY so the script can continue