### PR TITLE
Expand root partition & filesystem automatically on 1st boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Set default system locale and keyboard layout. This setting can also be changed 
 ##### `TIMEZONE`="Europe/Berlin"
 Set default system timezone. All available timezones can be found in the `/usr/share/zoneinfo/` directory. This setting can also be changed inside the running OS using the `dpkg-reconfigure tzdata` command.
 
+##### `EXPANDROOT`=true
+Expand the root partition and filesystem automatically on first boot.
+
 #### Basic system features:
 ##### `ENABLE_CONSOLE`=true
 Enable serial console interface. Recommended if no monitor or keyboard is connected to the RPi2. In case of problems fe. if the network (auto) configuration failed - the serial console can be used to access the system.

--- a/rpi2-gen-image.sh
+++ b/rpi2-gen-image.sh
@@ -714,36 +714,40 @@ if [ "$EXPANDROOT" = true ] ; then
   cat <<EOF > $R/tmp/rc.local.resize2fs
 #cut start#
 ROOT_PART=\$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
-PART_NUM=\${ROOT_PART#mmcblk0p}
+PART_NUM=\$(echo \{ROOT_PART} | grep -o '[1-9][0-9]*$')
+switch "\${ROOT_PART}"
+case mmcblk0*) ROOT_DEV=mmcblk0 ;;
+case sda*)     ROOT_DEV=sda ;;
+esac
 if [ "\$PART_NUM" = "\$ROOT_PART" ]; then
   logger -t "rpi2-gen-image" "\$ROOT_PART is not an SD card. Don't know how to expand"
   return 0
 fi
 # NOTE: the NOOBS partition layout confuses parted. For now, let's only
 # agree to work with a sufficiently simple partition layout
-if [ "\$PART_NUM" -ne 2 ]; then
+if [ "\$PART_NUM" -gt 2 ]; then
   logger -t "rpi2-gen-image" "Your partition layout is not currently supported by this tool."
   return 0
 fi
 
-LAST_PART_NUM=\$(parted /dev/mmcblk0 -ms unit s p | tail -n 1 | cut -f 1 -d:)
+LAST_PART_NUM=\$(parted /dev/\${ROOT_DEV} -ms unit s p | tail -n 1 | cut -f 1 -d:)
 if [ \$LAST_PART_NUM -ne \$PART_NUM ]; then
   logger -t "rpi2-gen-image" "\$ROOT_PART is not the last partition. Don't know how to expand"
   return 0
 fi
 
 # Get the starting offset of the root partition
-PART_START=\$(parted /dev/mmcblk0 -ms unit s p | grep "^\${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
+PART_START=\$(parted /dev/\${ROOT_DEV} -ms unit s p | grep "^\${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
 [ "\$PART_START" ] || return 1
 
 # Get the possible last sector for the root partition
-PART_LAST=\$(fdisk -l /dev/mmcblk0 | grep '^Disk.*sectors' | awk '{ print \$7 - 1 }')
+PART_LAST=\$(fdisk -l /dev/\${ROOT_DEV} | grep '^Disk.*sectors' | awk '{ print \$7 - 1 }')
 [ "\$PART_LAST" ] || return 1
 
 # Return value will likely be error for fdisk as it fails to reload the
 # partition table because the root fs is mounted
 ### Since rc.local is run with "sh -e", let's add "|| true" to prevent premature exit
-fdisk /dev/mmcblk0 <<EOF2 || true
+fdisk /dev/\${ROOT_DEV} <<EOF2 || true
 p
 d
 \$PART_NUM

--- a/rpi2-gen-image.sh
+++ b/rpi2-gen-image.sh
@@ -220,7 +220,7 @@ LANG=C chroot $R dpkg-reconfigure -f noninteractive tzdata
 
 # Set up default locales to "en_US.UTF-8" default
 if [ "$ENABLE_MINBASE" = false ] ; then
-  LANG=C chroot $R sed -i '/${DEFLOCAL}/s/^#//' /etc/locale.gen
+  LANG=C chroot $R sed -i "/${DEFLOCAL}/s/^#//" /etc/locale.gen
   LANG=C chroot $R locale-gen ${DEFLOCAL}
 fi
 

--- a/rpi2-gen-image.sh
+++ b/rpi2-gen-image.sh
@@ -714,10 +714,10 @@ if [ "$EXPANDROOT" = true ] ; then
   cat <<EOF > $R/tmp/rc.local.resize2fs
 #cut start#
 ROOT_PART=\$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
-PART_NUM=\$(echo \{ROOT_PART} | grep -o '[1-9][0-9]*$')
-switch "\${ROOT_PART}"
-case mmcblk0*) ROOT_DEV=mmcblk0 ;;
-case sda*)     ROOT_DEV=sda ;;
+PART_NUM=\$(echo \${ROOT_PART} | grep -o '[1-9][0-9]*$')
+case "\${ROOT_PART}" in
+  mmcblk0*) ROOT_DEV=mmcblk0 ;;
+  sda*)     ROOT_DEV=sda ;;
 esac
 if [ "\$PART_NUM" = "\$ROOT_PART" ]; then
   logger -t "rpi2-gen-image" "\$ROOT_PART is not an SD card. Don't know how to expand"


### PR DESCRIPTION
Hello,
here's a change based on raspi-config to add support for resizing root partition/filesystem when setting EXPANDROOT variable to true.
I fear I messed up a bit by committing and merging the DEFLOCAL change in my master branch all in one go, so this new expand-root branch has it too. Hopefuly it's not too bad, or someone can help with setting things right (git beginner here) ?