### PR TITLE
Use package git instead of git-core: Don't pull in obsolete packages

### DIFF
--- a/rpi2-gen-image.sh
+++ b/rpi2-gen-image.sh
@@ -145,7 +145,7 @@ APT_INCLUDES=${APT_INCLUDES:=""}
 APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo"
 
 # Packages required for bootstrapping
-REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git-core"
+REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git"
 MISSING_PACKAGES=""
 
 set +x


### PR DESCRIPTION
git-core is a transitional package since April 2010 and the no more
supported Debian 6 Squeeze.

This makes rpi2-gen-image stop pulling in ancient and obsolete transitional packages onto people's systems.